### PR TITLE
Add M1 mac in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-14 # M1
+          - macos-13 # Intel
         target:
           - command: 'mise x yamlfmt@latest -- yamlfmt -help'
           - command: 'mise x yamlfmt@0.1.0 -- yamlfmt -help'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-14 # M1
+          - macos-13 # Intel
         target:
           - tool-version: 'latest'
             command: 'yamlfmt -help'

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -18,7 +18,14 @@ on:
 jobs:
   tasks:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          # - macos-14 # M1 # asdf-typos does not support yet: https://github.com/aschiavon91/asdf-typos/pull/15
+          - macos-13 # Intel
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: asdf-vm/actions/setup@v3


### PR DESCRIPTION
Already worked, this PR just add the CI

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/